### PR TITLE
Update Dokka to latest version and fix build issues

### DIFF
--- a/android-nsd-rx/build.gradle
+++ b/android-nsd-rx/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'org.jetbrains.dokka-android'
+apply plugin: 'org.jetbrains.dokka'
 apply plugin: 'jacoco'
 
 jacoco {
@@ -47,20 +47,19 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:1.1.3"
 }
 
-dokka {
-    noStdlibLink = false
-    includeNonPublic = false
-    skipEmptyPackages = true
-    outputFormat = 'html'
-    outputDirectory = "$buildDir/javadoc"
+dokkaJavadoc.configure {
+    dokkaSourceSets {
+        named("main") {
+            noAndroidSdkLink.set(false)
+            includeNonPublic.set(false)
+            skipEmptyPackages.set(true)
+            outputDirectory.set(buildDir.resolve("javadoc"))
+            sourceRoots.setFrom(file("src/main/java"))
+        }
+    }
 }
 
 afterEvaluate { project ->
-    task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaAndroidTask) {
-        outputFormat = 'javadoc'
-        outputDirectory = "$buildDir/javadoc"
-        inputs.dir 'src/main/java'
-    }
 
     task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
         archiveClassifier.set("javadoc")

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18"
+        classpath "org.jetbrains.dokka:dokka-gradle-plugin:1.7.20"
     }
 }
 


### PR DESCRIPTION
Updates Dokka to the latest version (that seems to be in line with the Kotlin versions now?) configured after the documentation on https://github.com/Kotlin/dokka

I have never used Dokka myself but the `gradle dokkaJavadoc` command now seems to be running and creates output that looks reasonable.

<img width="389" alt="grafik" src="https://user-images.githubusercontent.com/9012887/200078555-97ea5b11-544c-427d-872e-d1ea71c7c0a0.png">

---

Unfortunately PRs here are not run on a CI, so please test locally @ToxicBakery. 😊 
