### PR TITLE
Update CI build task to use new Maven publishing task

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
               echo "signing.password=${SIGNING_PASSWORD}" >> "gradle.properties"
               echo "signing.secretKeyRingFile=../maven.keystore" >> "gradle.properties"
               gpg --cipher-algo AES256 --yes --batch --passphrase=$ENC_FILE_KEY maven.keystore.gpg
-              ./gradlew uploadArchives
+              ./gradlew publish
             fi
 workflows:
   version: 2

--- a/android-nsd-rx/build.gradle
+++ b/android-nsd-rx/build.gradle
@@ -34,6 +34,14 @@ android {
         }
     }
     namespace 'com.toxicbakery.library.nsd.rx'
+
+    publishing {
+        singleVariant("release") {
+            // if you don't want sources/javadoc, remove these lines
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 dependencies {
@@ -56,24 +64,6 @@ dokkaJavadoc.configure {
             outputDirectory.set(buildDir.resolve("javadoc"))
             sourceRoots.setFrom(file("src/main/java"))
         }
-    }
-}
-
-afterEvaluate { project ->
-
-    task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
-        archiveClassifier.set("javadoc")
-        from "$buildDir/javadoc"
-    }
-
-    task sourcesJar(type: Jar) {
-        archiveClassifier.set("sources")
-        from android.sourceSets.main.java.srcDirs
-    }
-
-    artifacts {
-        archives sourcesJar
-        archives javadocJar
     }
 }
 

--- a/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/ProtocolType.java
+++ b/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/ProtocolType.java
@@ -1,13 +1,13 @@
 package com.toxicbakery.library.nsd.rx;
 
 import android.net.nsd.NsdManager;
+
 import androidx.annotation.IntDef;
 
+import kotlin.annotation.AnnotationRetention;
 import kotlin.annotation.Retention;
 
-@Retention()
-@IntDef({
-        NsdManager.PROTOCOL_DNS_SD
-})
+@Retention(value = AnnotationRetention.SOURCE)
+@IntDef({NsdManager.PROTOCOL_DNS_SD})
 public @interface ProtocolType {
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -30,6 +30,9 @@ afterEvaluate { project ->
     publishing {
         publications {
             mavenJava(MavenPublication) {
+                artifact sourcesJar
+                artifact javadocJar
+
                 artifactId = POM_ARTIFACT_ID
 
                 pom {

--- a/publish.gradle
+++ b/publish.gradle
@@ -30,8 +30,7 @@ afterEvaluate { project ->
     publishing {
         publications {
             mavenJava(MavenPublication) {
-                artifact sourcesJar
-                artifact javadocJar
+                from components.release
 
                 artifactId = POM_ARTIFACT_ID
 


### PR DESCRIPTION
When changing the publishing plugin in #2, I hadn’t updated the CI job’s configuration.

`gradle publish` should work now

As I don’t have the necessary credentials, I could only try `gradle publishAllPublicationsToMavenLocalRepository` locally but it did result in POMs, hashes, and build artifacts being created:

<img width="510" alt="grafik" src="https://user-images.githubusercontent.com/9012887/200135238-e6686239-2974-4a4e-9e39-7212c307e297.png">

🤞 

---

This is the POM that was created for me locally:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
  <modelVersion>4.0.0</modelVersion>
  <groupId>com.ToxicBakery.library.nsd.rx</groupId>
  <artifactId>android-nsd-rx</artifactId>
  <version>1.0.0-SNAPSHOT</version>
  <name>android-nsd-rx</name>
  <description>Android Network Service Discovery Rx</description>
  <url>https://github.com/ToxicBakery/Android-Nsd-Rx</url>
  <licenses>
    <license>
      <name>The Apache Software License, Version 2.0</name>
      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
      <distribution>repo</distribution>
    </license>
  </licenses>
  <developers>
    <developer>
      <id>toxicbakery</id>
      <name>Ian Thomas</name>
      <email>toxicbakery@gmail.com</email>
      <organization>Toxic Bakery</organization>
      <organizationUrl>https://github.com/ToxicBakery</organizationUrl>
    </developer>
  </developers>
  <scm>
    <connection>scm:git@github.com:ToxicBakery/Android-Nsd-Rx.git</connection>
    <developerConnection>scm:git@github.com:ToxicBakery/Android-Nsd-Rx.git</developerConnection>
    <url>https://github.com/ToxicBakery/Android-Nsd-Rx.git</url>
  </scm>
</project>
```

Compared to [your most recent build on mavenCentral](https://central.sonatype.dev/artifact/com.ToxicBakery.library.nsd.rx/android-nsd-rx/1.0.22), I noticed that the `packaging` ~~as well as the dependencies are~~ is missing. | **Update**: Dependencies are now added. See https://github.com/ToxicBakery/Android-Nsd-Rx/pull/5#issuecomment-1304614304

I’m not entirely sure though if they’re necessary 🤔 