### PR TITLE
Use RxJava3 instead of RxJava 2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
               echo "signing.password=${SIGNING_PASSWORD}" >> "gradle.properties"
               echo "signing.secretKeyRingFile=../maven.keystore" >> "gradle.properties"
               gpg --cipher-algo AES256 --yes --batch --passphrase=$ENC_FILE_KEY maven.keystore.gpg
-              ./gradlew uploadArchives
+              ./gradlew publish
             fi
 workflows:
   version: 2

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Android [NsdManager](https://developer.android.com/reference/android/net/nsd/Nsd
 ## Install
 
 ```groovy
-implementation 'com.ToxicBakery.library.nsd.rx:android-nsd-rx:1.+'
+implementation 'com.ToxicBakery.library.nsd.rx:android-nsd-rx:3.+'
 ```
 
 ## Creating a Manager

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Android [NsdManager](https://developer.android.com/reference/android/net/nsd/Nsd
 
 ## Install
 
+You can find this library on [MavenCentral](https://central.sonatype.dev/namespace/com.ToxicBakery.library.nsd.rx)
+
 ```groovy
 implementation 'com.ToxicBakery.library.nsd.rx:android-nsd-rx:3.+'
 ```

--- a/android-nsd-rx/build.gradle
+++ b/android-nsd-rx/build.gradle
@@ -24,6 +24,13 @@ android {
         targetSdkVersion 33
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     buildTypes {
         debug {
             testCoverageEnabled true
@@ -45,7 +52,7 @@ android {
 }
 
 dependencies {
-    implementation "io.reactivex.rxjava2:rxjava:2.2.21"
+    implementation "io.reactivex.rxjava3:rxjava:3.1.5"
     implementation "androidx.annotation:annotation:1.5.0"
 
     testImplementation 'junit:junit:4.13.2'

--- a/android-nsd-rx/build.gradle
+++ b/android-nsd-rx/build.gradle
@@ -34,6 +34,14 @@ android {
         }
     }
     namespace 'com.toxicbakery.library.nsd.rx'
+
+    publishing {
+        singleVariant("release") {
+            // if you don't want sources/javadoc, remove these lines
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
 }
 
 dependencies {
@@ -56,24 +64,6 @@ dokkaJavadoc.configure {
             outputDirectory.set(buildDir.resolve("javadoc"))
             sourceRoots.setFrom(file("src/main/java"))
         }
-    }
-}
-
-afterEvaluate { project ->
-
-    task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
-        archiveClassifier.set("javadoc")
-        from "$buildDir/javadoc"
-    }
-
-    task sourcesJar(type: Jar) {
-        archiveClassifier.set("sources")
-        from android.sourceSets.main.java.srcDirs
-    }
-
-    artifacts {
-        archives sourcesJar
-        archives javadocJar
     }
 }
 

--- a/android-nsd-rx/src/androidTest/java/com/toxicbakery/library/nsd/rx/RegistrationListenerRxTest.kt
+++ b/android-nsd-rx/src/androidTest/java/com/toxicbakery/library/nsd/rx/RegistrationListenerRxTest.kt
@@ -3,7 +3,7 @@ package com.toxicbakery.library.nsd.rx
 import android.net.nsd.NsdServiceInfo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.toxicbakery.library.nsd.rx.registration.*
-import io.reactivex.ObservableEmitter
+import io.reactivex.rxjava3.core.ObservableEmitter
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith

--- a/android-nsd-rx/src/androidTest/java/com/toxicbakery/library/nsd/rx/ResolveListenerRxTest.kt
+++ b/android-nsd-rx/src/androidTest/java/com/toxicbakery/library/nsd/rx/ResolveListenerRxTest.kt
@@ -4,7 +4,7 @@ import android.net.nsd.NsdServiceInfo
 import com.toxicbakery.library.nsd.rx.resolve.ResolveEvent
 import com.toxicbakery.library.nsd.rx.resolve.ResolveListenerRx
 import com.toxicbakery.library.nsd.rx.resolve.ServiceResolved
-import io.reactivex.ObservableEmitter
+import io.reactivex.rxjava3.core.ObservableEmitter
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock

--- a/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/NsdManagerRx.kt
+++ b/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/NsdManagerRx.kt
@@ -11,8 +11,8 @@ import com.toxicbakery.library.nsd.rx.registration.RegistrationEvent
 import com.toxicbakery.library.nsd.rx.registration.RegistrationListenerRx
 import com.toxicbakery.library.nsd.rx.resolve.ResolveEvent
 import com.toxicbakery.library.nsd.rx.resolve.ResolveListenerRx
-import io.reactivex.Observable
-import io.reactivex.ObservableEmitter
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.ObservableEmitter
 
 class NsdManagerRx {
 

--- a/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/ProtocolType.java
+++ b/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/ProtocolType.java
@@ -1,13 +1,13 @@
 package com.toxicbakery.library.nsd.rx;
 
 import android.net.nsd.NsdManager;
+
 import androidx.annotation.IntDef;
 
+import kotlin.annotation.AnnotationRetention;
 import kotlin.annotation.Retention;
 
-@Retention()
-@IntDef({
-        NsdManager.PROTOCOL_DNS_SD
-})
+@Retention(value = AnnotationRetention.SOURCE)
+@IntDef({NsdManager.PROTOCOL_DNS_SD})
 public @interface ProtocolType {
 }

--- a/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/discovery/DiscoveryListenerRx.kt
+++ b/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/discovery/DiscoveryListenerRx.kt
@@ -5,7 +5,7 @@ import android.net.nsd.NsdServiceInfo
 import com.toxicbakery.library.nsd.rx.DiscoveryStartFailedException
 import com.toxicbakery.library.nsd.rx.DiscoveryStopFailedException
 import com.toxicbakery.library.nsd.rx.INsdManagerCompat
-import io.reactivex.ObservableEmitter
+import io.reactivex.rxjava3.core.ObservableEmitter
 
 internal data class DiscoveryListenerRx(
         private val nsdManagerCompat: INsdManagerCompat,

--- a/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/registration/RegistrationListenerRx.kt
+++ b/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/registration/RegistrationListenerRx.kt
@@ -5,7 +5,7 @@ import android.net.nsd.NsdServiceInfo
 import com.toxicbakery.library.nsd.rx.INsdManagerCompat
 import com.toxicbakery.library.nsd.rx.RegistrationFailedException
 import com.toxicbakery.library.nsd.rx.UnregistrationFailedException
-import io.reactivex.ObservableEmitter
+import io.reactivex.rxjava3.core.ObservableEmitter
 
 internal data class RegistrationListenerRx(
         private val nsdManagerCompat: INsdManagerCompat,

--- a/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/resolve/ResolveListenerRx.kt
+++ b/android-nsd-rx/src/main/java/com/toxicbakery/library/nsd/rx/resolve/ResolveListenerRx.kt
@@ -3,7 +3,7 @@ package com.toxicbakery.library.nsd.rx.resolve
 import android.net.nsd.NsdManager
 import android.net.nsd.NsdServiceInfo
 import com.toxicbakery.library.nsd.rx.ResolveFailedException
-import io.reactivex.ObservableEmitter
+import io.reactivex.rxjava3.core.ObservableEmitter
 
 class ResolveListenerRx(
         private val emitter: ObservableEmitter<ResolveEvent>

--- a/android-nsd-rx/src/test/java/com/toxicbakery/library/nsd/rx/DiscoveryListenerRxTest.kt
+++ b/android-nsd-rx/src/test/java/com/toxicbakery/library/nsd/rx/DiscoveryListenerRxTest.kt
@@ -2,7 +2,7 @@ package com.toxicbakery.library.nsd.rx
 
 import android.net.nsd.NsdServiceInfo
 import com.toxicbakery.library.nsd.rx.discovery.*
-import io.reactivex.ObservableEmitter
+import io.reactivex.rxjava3.core.ObservableEmitter
 import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.mock

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,6 +16,13 @@ android {
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
     buildTypes {
         debug {
             testCoverageEnabled true
@@ -31,8 +38,8 @@ android {
 dependencies {
     implementation project(":android-nsd-rx")
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation "io.reactivex.rxjava2:rxjava:2.2.21"
-    implementation "io.reactivex.rxjava2:rxandroid:2.1.1"
+    implementation "io.reactivex.rxjava3:rxjava:3.1.5"
+    implementation "io.reactivex.rxjava3:rxandroid:3.0.0"
     implementation 'androidx.annotation:annotation:1.5.0'
 
     implementation 'androidx.appcompat:appcompat:1.5.1'

--- a/app/src/main/java/com/toxicbakery/application/nsd/rx/MainActivity.kt
+++ b/app/src/main/java/com/toxicbakery/application/nsd/rx/MainActivity.kt
@@ -2,23 +2,22 @@ package com.toxicbakery.application.nsd.rx
 
 import android.app.Activity
 import android.os.Bundle
-import androidx.annotation.IdRes
-import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
 import android.util.Log
 import android.view.View
 import android.widget.Button
 import android.widget.TextView
+import androidx.annotation.IdRes
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
 import com.toxicbakery.library.nsd.rx.NsdManagerRx
 import com.toxicbakery.library.nsd.rx.discovery.DiscoveryConfiguration
 import com.toxicbakery.library.nsd.rx.discovery.DiscoveryEvent
 import com.toxicbakery.library.nsd.rx.discovery.DiscoveryServiceFound
 import com.toxicbakery.library.nsd.rx.discovery.DiscoveryServiceLost
-import io.reactivex.android.schedulers.AndroidSchedulers
-import io.reactivex.disposables.Disposable
-import io.reactivex.disposables.Disposables
-import io.reactivex.schedulers.Schedulers
+import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
+import io.reactivex.rxjava3.disposables.Disposable
+import io.reactivex.rxjava3.schedulers.Schedulers
 
 class MainActivity : AppCompatActivity() {
 
@@ -28,7 +27,7 @@ class MainActivity : AppCompatActivity() {
 
     private val nsdManagerRx: NsdManagerRx by lazy { NsdManagerRx(this) }
     private val adapter: DiscoveryAdapter by lazy { DiscoveryAdapter() }
-    private var subscription: Disposable = Disposables.disposed()
+    private var subscription: Disposable = Disposable.disposed()
 
     private fun <T : View> Activity.bind(@IdRes id: Int) = lazy { findViewById<T>(id) }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,5 +23,5 @@ allprojects {
     String buildNumber = System.getenv('CIRCLE_BUILD_NUM') ?: "0"
 
     group 'com.ToxicBakery.library.nsd.rx'
-    version "1.0.${buildNumber}" + (isTag ? "" : "-SNAPSHOT")
+    version "3.0.${buildNumber}" + (isTag ? "" : "-SNAPSHOT")
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -30,6 +30,9 @@ afterEvaluate { project ->
     publishing {
         publications {
             mavenJava(MavenPublication) {
+                artifact sourcesJar
+                artifact javadocJar
+
                 artifactId = POM_ARTIFACT_ID
 
                 pom {

--- a/publish.gradle
+++ b/publish.gradle
@@ -30,8 +30,7 @@ afterEvaluate { project ->
     publishing {
         publications {
             mavenJava(MavenPublication) {
-                artifact sourcesJar
-                artifact javadocJar
+                from components.release
 
                 artifactId = POM_ARTIFACT_ID
 


### PR DESCRIPTION
Based on #5’s branch. If changes were necessary there, please rebase/merge `master` into this branch first.

This PR updates RxJava from version 2 to version 3, updating imports to be compatible with RxJava3.

I’ve updated the library’s version number to 3.0 so show the breaking change as RxJava3 is incompatible with RxJava2 and vice versa.